### PR TITLE
Fix: When the app is frozen (e.g. packaged with PyInstaller), the YOLO model and charset are re-downloaded each time the app is launched

### DIFF
--- a/AntiCAP/utils/common.py
+++ b/AntiCAP/utils/common.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import io
 import base64
 import cv2
@@ -7,7 +8,11 @@ from PIL import Image
 
 def get_model_path(filename: str) -> str:
     """Get absolute path to a model file."""
-    current_dir = os.path.dirname(__file__)
+    if getattr(sys, "frozen", False):
+        # If the application is frozen (e.g., packaged with PyInstaller), use executable path
+        current_dir = os.path.dirname(sys.executable)
+    else:
+        current_dir = os.path.dirname(__file__)
     package_root = os.path.dirname(current_dir)
     return os.path.join(package_root, 'AntiCAP-Models', filename)
 

--- a/AntiCAP/utils/common.py
+++ b/AntiCAP/utils/common.py
@@ -9,12 +9,12 @@ from PIL import Image
 def get_model_path(filename: str) -> str:
     """Get absolute path to a model file."""
     if getattr(sys, "frozen", False):
-        # If the application is frozen (e.g., packaged with PyInstaller), use executable path
-        current_dir = os.path.dirname(sys.executable)
+        # If the application is frozen (e.g., packaged with PyInstaller), use the executable directory directly
+        base_dir = os.path.dirname(sys.executable)
     else:
-        current_dir = os.path.dirname(__file__)
-    package_root = os.path.dirname(current_dir)
-    return os.path.join(package_root, 'AntiCAP-Models', filename)
+        # In development, use the package root (one level above this file's directory)
+        base_dir = os.path.dirname(os.path.dirname(__file__))
+    return os.path.join(base_dir, 'AntiCAP-Models', filename)
 
 def decode_base64_to_image(base64_string: str) -> Image.Image:
     """Decode base64 string to PIL Image."""

--- a/AntiCAP/utils/manager.py
+++ b/AntiCAP/utils/manager.py
@@ -21,13 +21,14 @@ class ModelManager:
 
     def _download_models_if_needed(self):
         if getattr(sys, "frozen", False):
-            # If the application is frozen (e.g., packaged with PyInstaller), use executable path
-            current_dir = os.path.dirname(sys.executable)
+            # If the application is frozen (e.g., packaged with PyInstaller), place models next to the executable
+            base_dir = os.path.dirname(sys.executable)
+            output_dir = os.path.join(base_dir, "AntiCAP-Models")
         else:
+            # When running from source, use the AntiCAP package root as the base
             current_dir = os.path.dirname(__file__)
-        # Go up one level to AntiCAP root
-        package_root = os.path.dirname(current_dir)
-        output_dir = os.path.join(package_root, "AntiCAP-Models")
+            package_root = os.path.dirname(current_dir)
+            output_dir = os.path.join(package_root, "AntiCAP-Models")
 
         base_url = "https://newark81.vip/AntiCAP-Models/"
         filenames = [

--- a/AntiCAP/utils/manager.py
+++ b/AntiCAP/utils/manager.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+import sys
 import time
 import urllib.parse
 import requests
@@ -19,7 +20,11 @@ class ModelManager:
         onnxruntime.set_default_logger_severity(3)
 
     def _download_models_if_needed(self):
-        current_dir = os.path.dirname(__file__)
+        if getattr(sys, "frozen", False):
+            # If the application is frozen (e.g., packaged with PyInstaller), use executable path
+            current_dir = os.path.dirname(sys.executable)
+        else:
+            current_dir = os.path.dirname(__file__)
         # Go up one level to AntiCAP root
         package_root = os.path.dirname(current_dir)
         output_dir = os.path.join(package_root, "AntiCAP-Models")


### PR DESCRIPTION
add if-else branch judgement in util/common.py and util/manager.py to handle the situation when the application is in frozen state.